### PR TITLE
Issue #10 - BCM2835 can be treated the same as BCM2708

### DIFF
--- a/lib/usonic.js
+++ b/lib/usonic.js
@@ -26,7 +26,7 @@ var init = function (callback) {
 
         var hardware = stdout.split(':')[1].trim();
 
-        if (hardware === 'BCM2708') {
+	if ((hardware === 'BCM2708') || (hardware === 'BCM2835')) {
             usonic.init(1);
         } else if (hardware === 'BCM2709') {
             usonic.init(2);


### PR DESCRIPTION
Later versions of the chip follow the same scheme, there are now three pieces of silicon, BCM2708, BCM2709 and BCM2710 and three packages BCM2835, BCM2836 and BCM2837. It seems that BCM2835 can be treated the same as BCM2708